### PR TITLE
Remove abonnement check in partner lookup

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -15,7 +15,7 @@ import no.nav.syfo.application.ApplicationServer
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.createApplicationEngine
 import no.nav.syfo.db.Database
-import no.nav.syfo.services.ElektroniskAbonomentService
+import no.nav.syfo.services.PartnerInformasjonService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -43,9 +43,9 @@ fun main() {
 
     val database = Database(environment, vaultSecrets)
 
-    val behandlerService = ElektroniskAbonomentService(database, environment.databasePrefix)
+    val partnerInformasjonService = PartnerInformasjonService(database, environment.databasePrefix)
 
-    val applicationEngine = createApplicationEngine(environment, applicationState, jwkProvider, behandlerService)
+    val applicationEngine = createApplicationEngine(environment, applicationState, jwkProvider, partnerInformasjonService)
     val applicationServer = ApplicationServer(applicationEngine, applicationState)
 
     applicationServer.start()

--- a/src/main/kotlin/no/nav/syfo/aksessering/api/BehandlerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/api/BehandlerApi.kt
@@ -7,10 +7,10 @@ import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.routing.route
 import no.nav.syfo.log
-import no.nav.syfo.services.ElektroniskAbonoment
-import no.nav.syfo.services.ElektroniskAbonomentService
+import no.nav.syfo.services.PartnerInformasjon
+import no.nav.syfo.services.PartnerInformasjonService
 
-fun Route.registerBehandlerApi(elektroniskAbonomentService: ElektroniskAbonomentService) {
+fun Route.registerBehandlerApi(partnerInformasjonService: PartnerInformasjonService) {
     route("/v1") {
         get("/behandler") {
             log.info("Recived call to /api/v1/behandler")
@@ -19,11 +19,11 @@ fun Route.registerBehandlerApi(elektroniskAbonomentService: ElektroniskAbonoment
             if (herid.isNullOrEmpty()) {
                 log.info("Mangler query parameters: herid")
                 call.respond(HttpStatusCode.BadRequest)
-            } else if (elektroniskAbonomentService.finnParnterInformasjon(herid).isEmpty()) {
-                log.info("Fant ingen elektroniskAbonoment for akutell herid")
-                call.respond(emptyList<ElektroniskAbonoment>())
+            } else if (partnerInformasjonService.finnPartnerInformasjon(herid).isEmpty()) {
+                log.info("Fant ingen partnerInformasjon for akutell herid")
+                call.respond(emptyList<PartnerInformasjon>())
             } else {
-                call.respond(elektroniskAbonomentService.finnParnterInformasjon(herid))
+                call.respond(partnerInformasjonService.finnPartnerInformasjon(herid))
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
@@ -1,0 +1,28 @@
+package no.nav.syfo.aksessering.db
+
+import java.sql.ResultSet
+import no.nav.syfo.db.DatabaseInterface
+import no.nav.syfo.db.toList
+import no.nav.syfo.services.PartnerInformasjon
+
+fun DatabaseInterface.hentPartnerInformasjon(
+    herid: String,
+    databasePrefix: String
+): List<PartnerInformasjon> =
+        connection.use { connection ->
+            connection.prepareStatement(
+                    """
+                SELECT partner.partner_id
+                FROM $databasePrefix.PARTNER partner
+                WHERE partner.her_id=?
+                """
+            ).use {
+                it.setString(1, herid)
+                it.executeQuery().toList { toPartnerInformasjon() }
+            }
+        }
+
+fun ResultSet.toPartnerInformasjon(): PartnerInformasjon =
+        PartnerInformasjon(
+                getBigDecimal("partner_id").toInt()
+        )

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEngine.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEngine.kt
@@ -26,13 +26,13 @@ import no.nav.syfo.aksessering.api.registerBehandlerApi
 import no.nav.syfo.application.api.registerNaisApi
 import no.nav.syfo.application.authentication.setupAuth
 import no.nav.syfo.log
-import no.nav.syfo.services.ElektroniskAbonomentService
+import no.nav.syfo.services.PartnerInformasjonService
 
 fun createApplicationEngine(
     env: Environment,
     applicationState: ApplicationState,
     jwkProvider: JwkProvider,
-    elektroniskAbonomentService: ElektroniskAbonomentService
+    partnerInformasjonService: PartnerInformasjonService
 ): ApplicationEngine =
         embeddedServer(Netty, env.applicationPort) {
             setupAuth(env, jwkProvider)
@@ -40,7 +40,7 @@ fun createApplicationEngine(
                 registerNaisApi(applicationState)
                 route("/api") {
                     authenticate {
-                        registerBehandlerApi(elektroniskAbonomentService)
+                        registerBehandlerApi(partnerInformasjonService)
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/services/PartnerInformasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/services/PartnerInformasjon.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.services
+
+data class PartnerInformasjon(
+    val partnerId: Int
+)

--- a/src/main/kotlin/no/nav/syfo/services/PartnerInformasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/PartnerInformasjonService.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.services
+
+import no.nav.syfo.aksessering.db.hentPartnerInformasjon
+import no.nav.syfo.db.DatabaseInterface
+
+class PartnerInformasjonService(
+    private val database: DatabaseInterface,
+    private val databasePrefix: String
+) {
+    fun finnPartnerInformasjon(herid: String): List<PartnerInformasjon> = database.hentPartnerInformasjon(herid, databasePrefix)
+}

--- a/src/test/kotlin/TestData.kt
+++ b/src/test/kotlin/TestData.kt
@@ -1,5 +1,10 @@
 import no.nav.syfo.services.ElektroniskAbonoment
+import no.nav.syfo.services.PartnerInformasjon
 
 fun getListElektroniskAbonoment(): List<ElektroniskAbonoment> {
+    return emptyList()
+}
+
+fun getListPartnerInformasjon(): List<PartnerInformasjon> {
     return emptyList()
 }

--- a/src/test/kotlin/api/BehandlerApiSpek.kt
+++ b/src/test/kotlin/api/BehandlerApiSpek.kt
@@ -4,7 +4,7 @@ import com.auth0.jwk.JwkProviderBuilder
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import genereateJWT
-import getListElektroniskAbonoment
+import getListPartnerInformasjon
 import io.ktor.application.install
 import io.ktor.auth.authenticate
 import io.ktor.features.ContentNegotiation
@@ -19,14 +19,14 @@ import java.nio.file.Paths
 import no.nav.syfo.Environment
 import no.nav.syfo.aksessering.api.registerBehandlerApi
 import no.nav.syfo.application.authentication.setupAuth
-import no.nav.syfo.services.ElektroniskAbonomentService
+import no.nav.syfo.services.PartnerInformasjonService
 import org.amshove.kluent.shouldBe
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class BehandlerApiSpek : Spek({
-    val elektroniskAbonomentService: ElektroniskAbonomentService = mockk()
-    io.mockk.coEvery { elektroniskAbonomentService.finnParnterInformasjon(any()) } returns getListElektroniskAbonoment()
+    val partnerInformasjonService: PartnerInformasjonService = mockk()
+    io.mockk.coEvery { partnerInformasjonService.finnPartnerInformasjon(any()) } returns getListPartnerInformasjon()
     fun withTestApplicationForApi(receiver: TestApplicationEngine, block: TestApplicationEngine.() -> Unit) {
         receiver.start()
         val environment = Environment(8080,
@@ -47,7 +47,7 @@ class BehandlerApiSpek : Spek({
             }
         }
         receiver.application.setupAuth(environment, jwkProvider)
-        receiver.application.routing { authenticate { registerBehandlerApi(elektroniskAbonomentService) } }
+        receiver.application.routing { authenticate { registerBehandlerApi(partnerInformasjonService) } }
 
         return receiver.block()
     }


### PR DESCRIPTION
According to Sigbjørn this isn't necessary when the lookup is for
GPs/fastlege. Not all GPs have a subscription/abonnement and they are all
still able to use dialogmelding - we don't want to miss out on those
lookup hits.